### PR TITLE
fix: Stop long-polling as soon as app is hidden to prevent client exceptions.

### DIFF
--- a/app/lib/application/backend_api/interceptors/auth_interceptor.dart
+++ b/app/lib/application/backend_api/interceptors/auth_interceptor.dart
@@ -1,28 +1,36 @@
 import 'dart:async';
 import 'package:chopper/chopper.dart';
 import 'package:emma/domain/i_user_repository.dart';
+import 'package:mutex/mutex.dart';
 
 /// See https://bdaya-dev.github.io/oidc/oidc-usage-accesstoken/
 class AuthInterceptor implements Interceptor {
   static const kAuthorizationHeader = 'Authorization';
 
+  static final Mutex _m = Mutex();
   final IUserRepository _userRepository;
 
   AuthInterceptor({required IUserRepository userRepository})
       : _userRepository = userRepository;
 
   @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) {
+  FutureOr<Response<BodyType>> intercept<BodyType>(
+      Chain<BodyType> chain) async {
     final request = chain.request;
-    _tryAddAccessToken(request.headers);
+    await _tryAddAccessToken(request.headers);
     return chain.proceed(request);
   }
 
-  void _tryAddAccessToken(Map<String, String> headers) {
+  Future<void> _tryAddAccessToken(Map<String, String> headers) async {
     if (headers.containsKey(kAuthorizationHeader)) {
       // do nothing if header already exists.
       return;
     }
+
+    // refresh access token in case it was not refreshed in time
+    // because app was "idle".
+    await _m.protect(() => _userRepository
+        .refreshAccessTokenIfAboutToExpire(const Duration(seconds: 15)));
 
     final accessToken = _userRepository.accessToken;
     if (accessToken == null) {

--- a/app/lib/application/logs/logs_store.dart
+++ b/app/lib/application/logs/logs_store.dart
@@ -1,0 +1,22 @@
+import 'package:logging/logging.dart';
+import 'package:signals/signals.dart';
+import 'package:signals/signals_flutter.dart';
+
+class LogsStore {
+  static final LogsStore _instance = LogsStore._();
+
+  LogsStore._();
+
+  static LogsStore get instance => _instance;
+
+  final ListSignal<LogRecord> records = listSignal([]);
+
+  void addLog(LogRecord record) {
+    batch(() {
+      records.add(record);
+      if (records.length > 25) {
+        records.removeAt(0);
+      }
+    });
+  }
+}

--- a/app/lib/application/logs/logs_store.dart
+++ b/app/lib/application/logs/logs_store.dart
@@ -14,7 +14,7 @@ class LogsStore {
   void addLog(LogRecord record) {
     batch(() {
       records.add(record);
-      if (records.length > 25) {
+      if (records.length > 31) {
         records.removeAt(0);
       }
     });

--- a/app/lib/domain/i_user_repository.dart
+++ b/app/lib/domain/i_user_repository.dart
@@ -8,4 +8,6 @@ abstract interface class IUserRepository {
 
   Future<void> login();
   Future<void> logout();
+
+  Future<void> refreshAccessTokenIfAboutToExpire(Duration tolerance);
 }

--- a/app/lib/infrastructure/oidc_user_repository.dart
+++ b/app/lib/infrastructure/oidc_user_repository.dart
@@ -101,20 +101,3 @@ class OidcUserRepository implements IUserRepository {
     });
   }
 }
-
-class _User {
-  _User.from(OidcUser oidcUser)
-      : userId = oidcUser.claims.subject,
-        givenName = oidcUser.claims.getTyped("given_name"),
-        refreshToken = oidcUser.token.refreshToken != null;
-
-  final String? userId;
-  final String givenName;
-  final bool refreshToken;
-
-  Map<String, dynamic> toMap() => {
-        "userId": userId,
-        "givenName": givenName,
-        "refreshToken": refreshToken,
-      };
-}

--- a/app/lib/infrastructure/oidc_user_repository.dart
+++ b/app/lib/infrastructure/oidc_user_repository.dart
@@ -87,15 +87,17 @@ class OidcUserRepository implements IUserRepository {
   }
 
   void _onUserChanged(OidcUser? oidcUser) {
-    final user = oidcUser == null ? null : _User.from(oidcUser);
-    _logger.info("User: ${user?.toMap()}");
+    final name = oidcUser?.claims.getTyped<String?>("given_name") ?? "";
+    final status = switch (oidcUser) {
+      null => UserStatus.unauthenticated,
+      _ => UserStatus.authenticated
+    };
+
+    _logger.info("user changed: ${{"name": name, "status": status}}");
 
     batch(() {
-      _status.value = switch (user) {
-        null => UserStatus.unauthenticated,
-        _ => UserStatus.authenticated
-      };
-      _name.value = user?.givenName ?? "";
+      _name.value = name;
+      _status.value = status;
     });
   }
 }

--- a/app/lib/infrastructure/oidc_user_repository.dart
+++ b/app/lib/infrastructure/oidc_user_repository.dart
@@ -70,6 +70,16 @@ class OidcUserRepository implements IUserRepository {
     await _manager.logout();
   }
 
+  @override
+  Future<void> refreshAccessTokenIfAboutToExpire(Duration tolerance) async {
+    final isAboutToExpire = _manager.currentUser?.token
+        .isAccessTokenAboutToExpire(tolerance: tolerance);
+
+    if (isAboutToExpire ?? false) {
+      await _manager.refreshToken();
+    }
+  }
+
   Future<void> _init() async {
     await _manager.init();
     _logger.info("Initialized");

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:emma/app.dart';
+import 'package:emma/application/logs/logs_store.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
@@ -24,6 +25,8 @@ Future<void> main() async {
         stackTrace: record.stackTrace,
         zone: record.zone);
   });
+
+  Logger.root.onRecord.listen(LogsStore.instance.addLog);
 
   runApp(const App());
 }

--- a/app/lib/ui/devices/devices_screen.dart
+++ b/app/lib/ui/devices/devices_screen.dart
@@ -8,7 +8,7 @@ import 'package:emma/ui/devices/widgets/devices_list.dart';
 import 'package:emma/ui/locator.dart';
 import 'package:emma/ui/shared/noop.dart';
 import 'package:emma/ui/shared/app_bar_command_progress_indicator.dart';
-import 'package:emma/ui/utils/polling/long_polling_timer.dart';
+import 'package:emma/ui/utils/polling/long_polling_handler.dart';
 import 'package:flutter/material.dart';
 
 class DevicesScreen extends StatefulWidget {
@@ -19,7 +19,7 @@ class DevicesScreen extends StatefulWidget {
 }
 
 class _DevicesScreenState extends State<DevicesScreen> {
-  LongPollingTimer? _longPollingTimer;
+  LongPollingHandler? _longPollingHandler;
 
   // The view model has to be stored in the state for it to work.
   // Otherwise the DevicesVieModel would be created multiple times
@@ -31,13 +31,13 @@ class _DevicesScreenState extends State<DevicesScreen> {
     super.initState();
     viewModel = locator.get<DevicesViewModel>();
     viewModel.init();
-    _longPollingTimer = LongPollingTimer(const Duration(seconds: 1), viewModel.refresh.call);
+    _longPollingHandler = LongPollingHandler(const Duration(seconds: 1), viewModel.refresh.call);
   }
 
   @override
   void dispose() {
     super.dispose();
-    _longPollingTimer?.dispose();
+    _longPollingHandler?.dispose();
   }
 
   @override

--- a/app/lib/ui/devices/devices_screen.dart
+++ b/app/lib/ui/devices/devices_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:emma/ui/app_icons.dart';
 import 'package:emma/ui/app_navigator.dart';
 import 'package:emma/ui/devices/add/select_device_category_screen.dart';

--- a/app/lib/ui/devices/devices_screen.dart
+++ b/app/lib/ui/devices/devices_screen.dart
@@ -37,7 +37,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
   @override
   void dispose() {
     super.dispose();
-    _longPollingTimer?.cancel();
+    _longPollingTimer?.dispose();
   }
 
   @override

--- a/app/lib/ui/devices/devices_screen.dart
+++ b/app/lib/ui/devices/devices_screen.dart
@@ -8,6 +8,7 @@ import 'package:emma/ui/devices/widgets/devices_list.dart';
 import 'package:emma/ui/locator.dart';
 import 'package:emma/ui/shared/noop.dart';
 import 'package:emma/ui/shared/app_bar_command_progress_indicator.dart';
+import 'package:emma/ui/utils/polling/long_polling_timer.dart';
 import 'package:flutter/material.dart';
 
 class DevicesScreen extends StatefulWidget {
@@ -18,8 +19,7 @@ class DevicesScreen extends StatefulWidget {
 }
 
 class _DevicesScreenState extends State<DevicesScreen> {
-  bool _disposed = false;
-  Timer? _timer;
+  LongPollingTimer? _longPollingTimer;
 
   // The view model has to be stored in the state for it to work.
   // Otherwise the DevicesVieModel would be created multiple times
@@ -31,14 +31,13 @@ class _DevicesScreenState extends State<DevicesScreen> {
     super.initState();
     viewModel = locator.get<DevicesViewModel>();
     viewModel.init();
-    _timer = Timer(const Duration(seconds: 1), _timerCallback);
+    _longPollingTimer = LongPollingTimer(const Duration(seconds: 1), viewModel.refresh.call);
   }
 
   @override
   void dispose() {
     super.dispose();
-    _disposed = true;
-    _timer?.cancel();
+    _longPollingTimer?.cancel();
   }
 
   @override
@@ -57,17 +56,5 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
   void _startAddFlow() {
     AppNavigator.push(const SelectDeviceCategoryScreen());
-  }
-
-  Future<void> _timerCallback() async {
-    var success = false;
-    do {
-      success = await viewModel.refresh();
-    } while (!_disposed && success);
-
-    if (!success) {
-      // on failure: retry after 30 seconds
-      _timer = Timer(const Duration(seconds: 30), _timerCallback);
-    }
   }
 }

--- a/app/lib/ui/home/home_screen.dart
+++ b/app/lib/ui/home/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:emma/ui/home/home_view_model.dart';
 import 'package:emma/ui/home/status/home_status_view.dart';
 import 'package:emma/ui/locator.dart';
 import 'package:emma/ui/shared/app_bar_command_progress_indicator.dart';
+import 'package:emma/ui/utils/polling/long_polling_timer.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -14,8 +15,7 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  bool _disposed = false;
-  Timer? _timer;
+  LongPollingTimer? _longPollingTimer;
 
   late final HomeViewModel viewModel;
 
@@ -24,14 +24,13 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     viewModel = locator.get<HomeViewModel>();
     viewModel.init();
-    _timer = Timer(const Duration(seconds: 1), _timerCallback);
+    _longPollingTimer = LongPollingTimer(const Duration(seconds: 1), viewModel.refresh.call);
   }
 
   @override
   void dispose() {
     super.dispose();
-    _disposed = true;
-    _timer?.cancel();
+    _longPollingTimer?.cancel();
   }
 
   @override
@@ -57,17 +56,5 @@ class _HomeScreenState extends State<HomeScreen> {
             ],
           ),
         ));
-  }
-
-  Future<void> _timerCallback() async {
-    var success = false;
-    do {
-      success = await viewModel.refresh();
-    } while (!_disposed && success);
-
-    if (!success) {
-      // on failure: retry after 30 seconds
-      _timer = Timer(const Duration(seconds: 30), _timerCallback);
-    }
   }
 }

--- a/app/lib/ui/home/home_screen.dart
+++ b/app/lib/ui/home/home_screen.dart
@@ -4,7 +4,7 @@ import 'package:emma/ui/home/home_view_model.dart';
 import 'package:emma/ui/home/status/home_status_view.dart';
 import 'package:emma/ui/locator.dart';
 import 'package:emma/ui/shared/app_bar_command_progress_indicator.dart';
-import 'package:emma/ui/utils/polling/long_polling_timer.dart';
+import 'package:emma/ui/utils/polling/long_polling_handler.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -15,7 +15,7 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  LongPollingTimer? _longPollingTimer;
+  LongPollingHandler? _longPollingHandler;
 
   late final HomeViewModel viewModel;
 
@@ -24,13 +24,13 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     viewModel = locator.get<HomeViewModel>();
     viewModel.init();
-    _longPollingTimer = LongPollingTimer(const Duration(seconds: 1), viewModel.refresh.call);
+    _longPollingHandler = LongPollingHandler(const Duration(seconds: 1), viewModel.refresh.call);
   }
 
   @override
   void dispose() {
     super.dispose();
-    _longPollingTimer?.dispose();
+    _longPollingHandler?.dispose();
   }
 
   @override

--- a/app/lib/ui/home/home_screen.dart
+++ b/app/lib/ui/home/home_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:emma/ui/home/home_view_model.dart';
 import 'package:emma/ui/home/status/home_status_view.dart';
 import 'package:emma/ui/locator.dart';

--- a/app/lib/ui/home/home_screen.dart
+++ b/app/lib/ui/home/home_screen.dart
@@ -30,7 +30,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void dispose() {
     super.dispose();
-    _longPollingTimer?.cancel();
+    _longPollingTimer?.dispose();
   }
 
   @override

--- a/app/lib/ui/home/profile/profile_screen.dart
+++ b/app/lib/ui/home/profile/profile_screen.dart
@@ -1,8 +1,10 @@
 import 'package:emma/infrastructure/window_size_writer.dart';
 import 'package:emma/ui/app_icons.dart';
+import 'package:emma/ui/app_navigator.dart';
 import 'package:emma/ui/home/profile/app_info.dart';
 import 'package:emma/ui/home/profile/development/screen_size_selector.dart';
 import 'package:emma/ui/locator.dart';
+import 'package:emma/ui/logs/logs_screen.dart';
 import 'package:emma/ui/user_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:signals/signals_flutter.dart';
@@ -26,12 +28,19 @@ class _ProfileScreenState extends State<ProfileScreen> {
   @override
   Widget build(BuildContext context) {
     final items = <Widget>[
-      Watch((context) => ListTile(
-            leading: const Icon(AppIcons.logout),
-            title: const Text("Logout"),
-            onTap: _vm.logout.call,
-            enabled: !_vm.logout.isRunning.value,
-          ))
+      ListTile(
+        leading: const Icon(Icons.bug_report),
+        title: const Text("Logs"),
+        onTap: () => AppNavigator.push(const LogsScreen()),
+      ),
+      Watch(
+        (context) => ListTile(
+          leading: const Icon(AppIcons.logout),
+          title: const Text("Logout"),
+          onTap: _vm.logout.call,
+          enabled: !_vm.logout.isRunning.value,
+        ),
+      )
     ];
 
     if (WindowSizeWriter.isSupported) {

--- a/app/lib/ui/logs/logs_screen.dart
+++ b/app/lib/ui/logs/logs_screen.dart
@@ -1,0 +1,44 @@
+import 'package:emma/application/logs/logs_store.dart';
+import 'package:flutter/material.dart';
+import 'package:signals/signals_flutter.dart';
+
+class LogsScreen extends StatefulWidget {
+  const LogsScreen({super.key});
+
+  @override
+  State<LogsScreen> createState() => _LogsScreenState();
+}
+
+class _LogsScreenState extends State<LogsScreen> {
+  final records = LogsStore.instance.records;
+
+  @override
+  Widget build(BuildContext context) {
+    const style = TextStyle(fontFamily: 'monospace');
+
+    return Scaffold(
+        appBar: AppBar(title: const Text("Logs")),
+        body: Watch(
+          (context) => ListView.separated(
+              padding: const EdgeInsets.all(8.0),
+              itemBuilder: (context, index) {
+                final record = records[records.length - 1 - index];
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(record.time.toIso8601String(), style: style),
+                    Text(record.toString(), style: style),
+                    if (record.error != null)
+                      Text(
+                        record.error.toString(),
+                        style: style.copyWith(
+                            color: Theme.of(context).colorScheme.error),
+                      )
+                  ],
+                );
+              },
+              separatorBuilder: (context, index) => const Divider(),
+              itemCount: records.length),
+        ));
+  }
+}

--- a/app/lib/ui/utils/polling/long_polling_handler.dart
+++ b/app/lib/ui/utils/polling/long_polling_handler.dart
@@ -1,15 +1,14 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
+import 'package:logging/logging.dart';
 
 class LongPollingHandler {
+  final _logger = Logger((LongPollingHandler).toString());
   final Future<bool> Function() _longPollingAction;
-
   late final AppLifecycleListener? _listener;
-
   Completer _completer = Completer()..complete();
   Timer? _timer;
-  
   bool _disposed = false;
 
   LongPollingHandler(
@@ -33,12 +32,14 @@ class LongPollingHandler {
   }
 
   void _onHide() {
+    _logger.fine("pause long polling.");
     if (_completer.isCompleted) {
       _completer = Completer();
     }
   }
 
   void _onShow() {
+    _logger.fine("resume long polling.");
     if (!_completer.isCompleted) {
       _completer.complete();
     }

--- a/app/lib/ui/utils/polling/long_polling_handler.dart
+++ b/app/lib/ui/utils/polling/long_polling_handler.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 
-class LongPollingTimer {
+class LongPollingHandler {
   final Future<bool> Function() _longPollingAction;
 
   late final AppLifecycleListener? _listener;
@@ -12,7 +12,7 @@ class LongPollingTimer {
   
   bool _disposed = false;
 
-  LongPollingTimer(
+  LongPollingHandler(
       Duration startDelay, Future<bool> Function() longPollingAction)
       : _longPollingAction = longPollingAction {
     _listener = AppLifecycleListener(onHide: _onHide, onShow: _onShow);

--- a/app/lib/ui/utils/polling/long_polling_timer.dart
+++ b/app/lib/ui/utils/polling/long_polling_timer.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+class LongPollingTimer {
+  final Future<bool> Function() _longPollingAction;
+
+  late final AppLifecycleListener? _listener;
+
+  Completer _completer = Completer()..complete();
+  Timer? _timer;
+  
+  bool _disposed = false;
+
+  LongPollingTimer(
+      Duration startDelay, Future<bool> Function() longPollingAction)
+      : _longPollingAction = longPollingAction {
+    _listener = AppLifecycleListener(onHide: _onHide, onShow: _onShow);
+    _timer = Timer(startDelay, _timerCallback);
+  }
+
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+
+    _disposed = true;
+    _listener?.dispose();
+    _timer?.cancel();
+    if (!_completer.isCompleted) {
+      _completer.complete();
+    }
+  }
+
+  void _onHide() {
+    if (_completer.isCompleted) {
+      _completer = Completer();
+    }
+  }
+
+  void _onShow() {
+    if (!_completer.isCompleted) {
+      _completer.complete();
+    }
+  }
+
+  Future<void> _timerCallback() async {
+    var success = true;
+    while (!_disposed && success) {
+      await _completer.future;
+      if (_disposed) {
+        return;
+      }
+
+      success = await _longPollingAction();
+      if (_disposed) {
+        return;
+      }
+
+      if (!success) {
+        // on failure: retry after 30 seconds
+        _timer = Timer(const Duration(seconds: 30), _timerCallback);
+        return;
+      }
+    }
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -616,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  mutex:
+    dependency: "direct main"
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   nonce:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   signals: ^5.2.2
   url_launcher: ^6.3.0
   flutter_launcher_icons: ^0.13.1
+  mutex: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
As soon as the app is shown in again, the long-polling continues.
In case of an expired access token, the access token is refreshed before the next request is made.