### PR TITLE
fix: fixes commit of transaction in `TransactionBehavior`

### DIFF
--- a/server/src/Emma.Application.Shared/Events/EventRequest.cs
+++ b/server/src/Emma.Application.Shared/Events/EventRequest.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Emma.Domain.Events;
-using MediatR;
 
 namespace Emma.Application.Shared.Events;
 
@@ -9,7 +8,6 @@ namespace Emma.Application.Shared.Events;
     "S2326:Unused type parameters should be removed",
     Justification = "TEventChannel is actually used."
 )]
-[RequiresTransaction]
-public sealed record EventRequest<TEvent, TEventChannel>(TEvent DomainEvent) : IRequest
+public sealed record EventRequest<TEvent, TEventChannel>(TEvent DomainEvent) : IEventRequest
     where TEvent : IEvent
     where TEventChannel : IEventChannel;

--- a/server/src/Emma.Application.Shared/Events/IEventRequest.cs
+++ b/server/src/Emma.Application.Shared/Events/IEventRequest.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Emma.Application.Shared.Events;
+
+public interface IEventRequest : IRequest;

--- a/server/src/Emma.Application.Shared/ICommand.cs
+++ b/server/src/Emma.Application.Shared/ICommand.cs
@@ -2,5 +2,4 @@ using MediatR;
 
 namespace Emma.Application.Shared;
 
-[RequiresTransaction]
 public interface ICommand : IRequest;

--- a/server/src/Emma.Application.Shared/RequiresTransactionAttribute.cs
+++ b/server/src/Emma.Application.Shared/RequiresTransactionAttribute.cs
@@ -1,8 +1,0 @@
-namespace Emma.Application.Shared;
-
-[AttributeUsage(
-    AttributeTargets.Class | AttributeTargets.Interface,
-    Inherited = true,
-    AllowMultiple = false
-)]
-public sealed class RequiresTransactionAttribute : Attribute;

--- a/server/src/Emma.Server/Bootstrapper.cs
+++ b/server/src/Emma.Server/Bootstrapper.cs
@@ -103,7 +103,10 @@ public static class Bootstrapper
         );
 
         // Pipeline
-        container.Collection.Register(typeof(IPipelineBehavior<,>), [typeof(LoggingBehavior<,>)]);
+        container.Collection.Register(
+            typeof(IPipelineBehavior<,>),
+            [typeof(LoggingBehavior<,>), typeof(TransactionBehavior<,>)]
+        );
     }
 
     private static void AddPersistence(Container container)

--- a/server/src/Emma.Server/appsettings.json
+++ b/server/src/Emma.Server/appsettings.json
@@ -4,7 +4,6 @@
       "Default": "Information",
       "Override": {
         "DotNetCore.CAP": "Information",
-        "Emma.Application.Shared.Events": "Debug",
         "Emma.Integrations.Shelly.Infrastructure.ShellyWebsocketMessageHandler": "Debug",
         "Microsoft.AspNetCore": "Warning",
         "Microsoft.EntityFrameworkCore": "Warning"


### PR DESCRIPTION
`autoCommit: true` only works if `ICapPublisher` is used to publish events. If there are no events to publish, the transaction is not committed.